### PR TITLE
!default value is not assigned for some variable

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -29,10 +29,10 @@ $pretty--2x: 1.2em !default;
 $pretty--colors: (primary, $pretty--color-primary), (info, $pretty--color-info), (success, $pretty--color-success), (warning, $pretty--color-warning), (danger, $pretty--color-danger) !default;
 
 // position
-$pretty-top: 8;
-$pretty-top-switch: ($pretty-top * 2) * 1%;
-$pretty-top-offset: calc((0% - (100% - 1em)) - #{$pretty-top * 1%});
-$pretty-top-offset-switch: calc((0% - (100% - 1em)) - #{$pretty-top-switch});
+$pretty-top: 8 !default;
+$pretty-top-switch: ($pretty-top * 2) * 1% !default;
+$pretty-top-offset: calc((0% - (100% - 1em)) - #{$pretty-top * 1%}) !default;
+$pretty-top-offset-switch: calc((0% - (100% - 1em)) - #{$pretty-top-switch}) !default;
 
 // dev 
 $pretty--debug: false !default;


### PR DESCRIPTION
Your code is based on 14px base value for font-size.
It's not necessary to have the same value for others. So Based on that there should be an option to override. I've checked the code and found that there's no '!default' value assigned in the _variables.scss file.

```
// position
$pretty-top: 8 !default;
$pretty-top-switch: ($pretty-top * 2) * 1% !default;
$pretty-top-offset: calc((0% - (100% - 1em)) - #{$pretty-top * 1%}) !default;
$pretty-top-offset-switch: calc((0% - (100% - 1em)) - #{$pretty-top-switch}) !default;
```